### PR TITLE
fix: create new bucket 

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ Example Usage:
     file_handle = bucket.get_file("foobar.txt")
     file_content = file_handle.get_content()
 
-    # delete a bucket (n.b. this will **NOT** delete the collab!)
-    client.delete_bucket("new_bucket_name")
+    # delete a bucket, and also delete the wiki associated with it)
+    client.delete_bucket("new_collab_name", delete_wiki=True)
+
 ```
 
 Read access of public buckets can be done without supplying a token:

--- a/ebrains_drive/bucket.py
+++ b/ebrains_drive/bucket.py
@@ -14,7 +14,7 @@ class Bucket(object):
     A dataproxy bucket
     n.b. for a dataset bucket, role & is_public may be None
     """
-    def __init__(self, client, name: str, objects_count: int, bytes: int, last_modified: str, is_public: bool = None, is_initialized: bool = None, role: str = None, *, public: bool= False, target: str='buckets', dataset_id: str=None) -> None:
+    def __init__(self, client, name: str, objects_count: int, bytes: int, last_modified: str=None, is_public: bool = None, is_initialized: bool = None, role: str = None, *, public: bool= False, target: str='buckets', dataset_id: str=None) -> None:
         if target != 'buckets' and target != 'datasets':
             raise InvalidParameter(f'Init Buckets exception: target can be left unset, but if set, must either be buckets or datasets')
         if public:

--- a/ebrains_drive/client.py
+++ b/ebrains_drive/client.py
@@ -142,7 +142,19 @@ class BucketApiClient(ClientBase):
 
     @on_401_raise_unauthorized("Failed. Note: BucketApiClient.create_new needs to have clb.drive:write as a part of scope.")
     def create_new(self, bucket_name: str, title=None, description="Created by ebrains_drive"):
-        # attempt to create new collab
+        """
+        Create a new bucket by first attempting to create a new wiki/collab. On 201 (created)
+        or 409 (conflict) initialize the bucket of the said wiki. The request to initialize the bucket 
+        will be retried up to 5 times, as it usually takes a few minutes for the newly initialized wiki
+        to allow buckets to be created.
+
+        :param:`bucket_name` the name of the to-be-created bucket (and wiki if needed)
+
+        :param:`title` the title of the to-be-created wiki (if unset, defaults to `bucket_name` param)
+
+        :param:`description` description of the to-be-created wiki. 
+        """
+
         self.send_request("POST", "https://wiki.ebrains.eu/rest/v1/collabs", json={
             "name": bucket_name,
             "title": title or bucket_name,
@@ -150,16 +162,34 @@ class BucketApiClient(ClientBase):
             "drive": True,
             "chat": True,
             "public": False
-        }, expected=201)
+        }, expected=(201, 409))
 
-        # activate the bucket for the said collab
-        self.send_request("POST", "/v1/buckets", json={
-            "bucket_name": bucket_name
-        }, expected=201)
+        fuse = 5
+        while True:
+            try:
+                self.send_request("POST", "/v1/buckets", json={
+                    "bucket_name": bucket_name
+                }, expected=201)
+                break
+            except Exception as e:
+                if fuse < 0:
+                    raise e from e
+                fuse -= 1
+                time.sleep(1)
+
     
-    @on_401_raise_unauthorized("Failed. Note: BucketApiClient.create_new needs to have clb.drive:write as a part of scope.")
-    def delete_bucket(self, bucket_name: str):
-        self.send_request("DELETE", f"/v1/buckets/{bucket_name}")
+    @on_401_raise_unauthorized("Failed. Note: BucketApiClient.delete_bucket needs to have clb.drive:write as a part of scope.")
+    def delete_bucket(self, bucket_name: str, *, delete_wiki=False):
+        """
+        Deletes an existing bucket.
+
+        :param:`bucket_name` name of the bucket (and - if delete_wiki is set - of the wiki) to be deleted
+
+        :param:`delete_wiki` if the wiki should also be deleted.
+        """
+        self.send_request("DELETE", f"/v1/buckets/{bucket_name}", expected=(200,))
+        if delete_wiki:
+            self.send_request("DELETE", f"https://wiki.ebrains.eu/rest/v1/collabs/{bucket_name}", expected=(200,))
     
     def send_request(self, method: str, url: str, *args, **kwargs):
 

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -31,7 +31,6 @@ bucket_json={
     'name': 'foo',
     'objects_count': 12,
     'bytes': 112233,
-    'last_modified': 'foo-bar',
     'is_public': False,
     'role': 'admin',
 }


### PR DESCRIPTION
create a new bucket (by creating a new wiki -> initialize new bucket) fails very often, as newly created wiki takes seconds to allow for the bucket to be initialized. 

This PR address this issue by adding a retry mechanism. 

(also addresses the issue where "last_modified" may be undefined for for buckets)