### PR TITLE
Fix an error when running tests, due to a recent change

### DIFF
--- a/ebrains_drive/client.py
+++ b/ebrains_drive/client.py
@@ -4,7 +4,7 @@ from abc import ABC
 import base64
 import json
 import time
-from copy import deepcopy
+from copy import copy, deepcopy
 from ebrains_drive.utils import on_401_raise_unauthorized
 from ebrains_drive.exceptions import ClientHttpError, TokenExpired, Unauthorized
 from ebrains_drive.repos import Repos
@@ -80,9 +80,11 @@ class ClientBase(ABC):
             # - accounts for if url was provided with leading slashes
             url = self.server.rstrip('/') + '/' + url.lstrip('/')
 
-        # deepcopy the kwargs so do not mutate the original kwargs
-        kwargs = deepcopy(kwargs)
-        headers = kwargs.get('headers', {})
+        # Copy the kwargs, and deepcopy the ones we change, so as not to mutate the original kwargs.
+        # We cannot deepcopy the whole thing, because some values (e.g. BufferedReader objects)
+        # cannot be pickled
+        kwargs = copy(kwargs)
+        headers = deepcopy(kwargs.get('headers', {}))
         headers.setdefault('Authorization', 'Bearer ' + self._token)
         kwargs['headers'] = headers
 


### PR DESCRIPTION
The error is as follows, and comes from the "files" argument to client.post, which in some cases cannot be pickled.

```
tests/test_files.py:63:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ebrains_drive/files.py:257: in upload
    self.client.post(upload_url, files=files)
ebrains_drive/client.py:68: in post
    return self.send_request('POST', *args, **kwargs)
ebrains_drive/client.py:139: in send_request
    return super().send_request(method, url, *args, **kwargs)
ebrains_drive/client.py:84: in send_request
    kwargs = deepcopy(kwargs)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py:146: in deepcopy
    y = copier(x, memo)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py:231: in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py:146: in deepcopy
    y = copier(x, memo)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py:231: in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py:146: in deepcopy
    y = copier(x, memo)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py:211: in _deepcopy_tuple
    y = [deepcopy(a, memo) for a in x]
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py:211: in <listcomp>
    y = [deepcopy(a, memo) for a in x]

E                           TypeError: cannot pickle '_io.BufferedReader' object

/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py:161: TypeError
```

The fix is to use copy in place of deepcopy for the `kwargs`, and then to only deepcopy the values that are changed.