### PR TITLE
ci/cd: build on push, release on tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,17 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
+
+  verify-tag:
+    name: verify tag conforms
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check tag conforms
+      run: |
+        trimmed_tag=${GITHUB_REF#refs/tags/}
+        echo trimmed_tag='"'$trimmed_tag'"'
+        exit [[ "$trimmed_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]
         
   publish-to-pypi:  
     name: >-
@@ -36,6 +47,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
     - build
+    - verify-tag
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+# adapted from https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#workflow-definition
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+        
+  publish-to-pypi:  
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ebrains-drive
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,11 +35,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-    - name: Check tag conforms
+    - name: "Check tag conforms ^[0-9]+\\.[0-9]+\\.[0-9]+$"
       run: |
         trimmed_tag=${GITHUB_REF#refs/tags/}
         echo trimmed_tag='"'$trimmed_tag'"'
-        exit [[ "$trimmed_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]
+        exit [[ "$trimmed_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
         
   publish-to-pypi:  
     name: >-


### PR DESCRIPTION
This PR adds CI/CD which:

- builds on each push
- publishes on pypi on tag

largely following guide from https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#workflow-definition 

---

edit: TODO: after merge, someone with pypi publish right (me, andrew etc) will need to continue the guide, specifically registering trusted publishing at https://pypi.org/manage/account/publishing/