### PR TITLE
feat: support multipart upload

### DIFF
--- a/ebrains_drive/bucket.py
+++ b/ebrains_drive/bucket.py
@@ -1,10 +1,16 @@
 from typing import Iterable
+import json
+import os
 import requests
 from ebrains_drive.exceptions import DoesNotExist, InvalidParameter, UpstreamAPIException
 from ebrains_drive.files import DataproxyFile
 from ebrains_drive.utils import on_401_raise_unauthorized
 from io import IOBase
+from tqdm import tqdm
 from typing import Union
+
+MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024  # 10 MB
+MUST_USE_MULTIPART_THRESHOLD = 1024 * 1024 * 1024  # 1 GB
 
 
 class Bucket(object):
@@ -96,8 +102,150 @@ class Bucket(object):
                 return file
         raise DoesNotExist(f"Cannot find {name}.")
 
+    def _get_filesize(self, filelike: Union[str, IOBase]) -> int:
+        if isinstance(filelike, str):
+            return os.path.getsize(filelike)
+        pos = filelike.seek(0, 2)
+        filelike.seek(0)
+        return pos
+
+    def _can_multipart_upload(self, filelike: Union[str, IOBase]) -> int:
+        """Returns file size; raises InvalidParameter if not larger than MULTIPART_CHUNK_SIZE."""
+        size = self._get_filesize(filelike)
+        if size <= MULTIPART_CHUNK_SIZE:
+            raise InvalidParameter(
+                f"multipart_upload requires file size > {MULTIPART_CHUNK_SIZE} bytes ({size} bytes given). Use upload() instead."
+            )
+        return size
+
+    @on_401_raise_unauthorized("Unauthorized")
+    def multipart_upload(self, filelike: Union[str, IOBase], filename: str, **kwargs):
+        """
+        Upload a file using multipart upload to the ebrains drive, supporting resumable uploads.
+
+        This method handles large file uploads by splitting them into chunks and uploading
+        each chunk separately using presigned URLs. It supports resuming interrupted uploads
+        via a local manifest file (`.multipart_manifest.json`), storing upload progress and
+        ETags for completed parts.
+
+        Parameters
+        ----------
+        filelike : str or IOBase
+            Path to the local file as a string, or a file-like object (e.g., open file handle).
+            If a string, the method opens and reads the file; if a file-like object, it must
+            support `.seek()` and `.read()` operations.
+        filename : str
+            Destination filename in the remote storage. Leading slashes are stripped.
+        **kwargs : dict, optional
+            Additional keyword arguments (currently unused; included for extensibility).
+
+        Notes
+        -----
+        - The manifest file is named `<filepath>.multipart_manifest.json` when a file path is provided.
+        - The manifest stores:
+            - `upload_id`: ID returned by the server for the multipart upload session.
+            - `etag_maps`: Dictionary mapping part numbers to ETags of completed parts.
+            - `next_offset`: Byte offset for the next chunk to upload (used for resuming).
+        - In case of interruption, the method resumes from the last saved `next_offset`.
+        - The manifest file is deleted upon successful completion of the upload.
+
+        Raises
+        ------
+        UpstreamAPIException
+            If the upload ID cannot be obtained from the server, or if a presigned URL
+            is missing for a part, or if other required responses are malformed.
+        """
+        sess = requests.Session()
+        filename = filename.lstrip("/")
+        self._can_multipart_upload(filelike)
+
+        filepath = filelike if isinstance(filelike, str) else None
+        manifest_path = f"{filepath}.multipart_manifest.json" if filepath else None
+
+        # Load manifest for resume, or start fresh
+        manifest = {}
+        if manifest_path and os.path.exists(manifest_path):
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+
+        upload_id = manifest.get("upload_id")
+        etag_maps: dict = manifest.get("etag_maps", {})
+
+        if not upload_id:
+            resp = self.client.put(f"/v1/{self.target}/{self.dataproxy_entity_name}/{filename}/multipart")
+            upload_id = resp.json().get("uploadId")
+            if not upload_id:
+                raise UpstreamAPIException("multipart_upload: failed to obtain uploadId.")
+            manifest = {"upload_id": upload_id, "etag_maps": {}, "next_offset": 0}
+            if manifest_path:
+                with open(manifest_path, "w") as f:
+                    json.dump(manifest, f)
+
+        next_offset = manifest.get("next_offset", 0)
+        part_number = len(etag_maps) + 1
+        file_size = self._get_filesize(filelike)
+
+        filehandle = open(filepath, "rb") if filepath else filelike
+        try:
+            filehandle.seek(next_offset)
+            with tqdm(
+                total=file_size, initial=next_offset, unit="B", unit_scale=True, unit_divisor=1024, desc=filename
+            ) as progress:
+                while True:
+                    chunk = filehandle.read(MULTIPART_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    resp = self.client.put(
+                        f"/v1/{self.target}/{self.dataproxy_entity_name}/{filename}/multipart/{upload_id}/{part_number}",
+                        params={"redirect": "false"},
+                    )
+                    part_url = resp.json().get("url")
+                    if not part_url:
+                        raise UpstreamAPIException(f"multipart_upload: no presigned URL for part {part_number}.")
+                    resp = sess.put(part_url, data=chunk)
+                    resp.raise_for_status()
+                    etag = resp.headers.get("etag", "").strip('"')
+                    etag_maps[str(part_number)] = etag
+                    next_offset += len(chunk)
+                    progress.update(len(chunk))
+                    if manifest_path:
+                        manifest["etag_maps"] = etag_maps
+                        manifest["next_offset"] = next_offset
+                        with open(manifest_path, "w") as f:
+                            json.dump(manifest, f)
+                    part_number += 1
+        finally:
+            if filepath:
+                filehandle.close()
+
+        resp = self.client.put(
+            f"/v1/{self.target}/{self.dataproxy_entity_name}/{filename}/multipart/{upload_id}",
+            params={"redirect": "false"},
+            json=etag_maps,
+        )
+
+        if manifest_path and os.path.exists(manifest_path):
+            os.remove(manifest_path)
+
     @on_401_raise_unauthorized("Unauthorized")
     def upload(self, filelike: Union[str, IOBase], filename: str, **kwargs):
+        """
+        Upload a file to the bucket. If the file size exceeds `MUST_USE_MULTIPART_THRESHOLD` (1GB),
+        this method automatically uses `multipart_upload` instead of a simple upload.
+
+        Parameters
+        ----------
+        filelike : str or IOBase
+            Path to the file or a file-like object (e.g., opened file handle).
+        filename : str
+            Destination filename in the bucket (leading slashes are stripped).
+        **kwargs : dict, optional
+            Additional keyword arguments passed to the underlying HTTP requests
+            (e.g., headers, timeout, etc.).
+        """
+        if self._get_filesize(filelike) > MUST_USE_MULTIPART_THRESHOLD:
+            # use multipart upload to stay way below 5G gateway limit
+            return self.multipart_upload(filelike, filename, **kwargs)
         filename = filename.lstrip("/")
         resp = self.client.put(f"/v1/{self.target}/{self.dataproxy_entity_name}/{filename}", **kwargs)
         upload_url = resp.json().get("url")

--- a/ebrains_drive/bucket.py
+++ b/ebrains_drive/bucket.py
@@ -104,7 +104,8 @@ class Bucket(object):
 
     def _get_filesize(self, filelike: Union[str, IOBase]) -> int:
         if isinstance(filelike, str):
-            return os.path.getsize(filelike)
+            with open(filelike, "rb") as fp:
+                return fp.seek(0, 2)
         pos = filelike.seek(0, 2)
         filelike.seek(0)
         return pos

--- a/ebrains_drive/bucket.py
+++ b/ebrains_drive/bucket.py
@@ -4,13 +4,14 @@ import os
 import requests
 from ebrains_drive.exceptions import DoesNotExist, InvalidParameter, UpstreamAPIException
 from ebrains_drive.files import DataproxyFile
-from ebrains_drive.utils import on_401_raise_unauthorized
+from ebrains_drive.utils import (
+    on_401_raise_unauthorized,
+    EBRAINS_DRIVE_MULTIPART_CHUNK_SIZE,
+    EBRAINS_DRIVE_MULTIPART_THRESHOLD,
+)
 from io import IOBase
 from tqdm import tqdm
 from typing import Union
-
-MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024  # 10 MB
-MUST_USE_MULTIPART_THRESHOLD = 1024 * 1024 * 1024  # 1 GB
 
 
 class Bucket(object):
@@ -104,18 +105,17 @@ class Bucket(object):
 
     def _get_filesize(self, filelike: Union[str, IOBase]) -> int:
         if isinstance(filelike, str):
-            with open(filelike, "rb") as fp:
-                return fp.seek(0, 2)
+            return os.path.getsize(filelike)
         pos = filelike.seek(0, 2)
         filelike.seek(0)
         return pos
 
     def _can_multipart_upload(self, filelike: Union[str, IOBase]) -> int:
-        """Returns file size; raises InvalidParameter if not larger than MULTIPART_CHUNK_SIZE."""
+        """Returns file size; raises InvalidParameter if not larger than EBRAINS_DRIVE_MULTIPART_CHUNK_SIZE."""
         size = self._get_filesize(filelike)
-        if size <= MULTIPART_CHUNK_SIZE:
+        if size <= EBRAINS_DRIVE_MULTIPART_CHUNK_SIZE:
             raise InvalidParameter(
-                f"multipart_upload requires file size > {MULTIPART_CHUNK_SIZE} bytes ({size} bytes given). Use upload() instead."
+                f"multipart_upload requires file size > {EBRAINS_DRIVE_MULTIPART_CHUNK_SIZE} bytes ({size} bytes given). Use upload() instead."
             )
         return size
 
@@ -193,7 +193,7 @@ class Bucket(object):
                 total=file_size, initial=next_offset, unit="B", unit_scale=True, unit_divisor=1024, desc=filename
             ) as progress:
                 while True:
-                    chunk = filehandle.read(MULTIPART_CHUNK_SIZE)
+                    chunk = filehandle.read(EBRAINS_DRIVE_MULTIPART_CHUNK_SIZE)
                     if not chunk:
                         break
                     resp = self.client.put(
@@ -244,7 +244,7 @@ class Bucket(object):
             Additional keyword arguments passed to the underlying HTTP requests
             (e.g., headers, timeout, etc.).
         """
-        if self._get_filesize(filelike) > MUST_USE_MULTIPART_THRESHOLD:
+        if self._get_filesize(filelike) > EBRAINS_DRIVE_MULTIPART_THRESHOLD:
             # use multipart upload to stay way below 5G gateway limit
             return self.multipart_upload(filelike, filename, **kwargs)
         filename = filename.lstrip("/")

--- a/ebrains_drive/utils.py
+++ b/ebrains_drive/utils.py
@@ -4,6 +4,8 @@ import inspect
 from functools import wraps
 from typing import Type
 from urllib.parse import urlencode
+import os
+
 from ebrains_drive.exceptions import ClientHttpError, DoesNotExist, Unauthorized
 
 
@@ -98,3 +100,13 @@ def utf8lize(obj):
         return obj.encode("utf-8")
 
     return obj
+
+EBRAINS_DRIVE_MULTIPART_CHUNK_SIZE = int(os.getenv("EBRAINS_DRIVE_MULTIPART_CHUNK_SIZE", 10 * 1024 * 1024))
+"""Chunk size of mulitpart upload. Doubles as a lower threshold for qualifying for multipart upload. (default: 10M)
+
+n.b. there is an undocumented lower hard threshold for multipart upload of 5M"""
+
+EBRAINS_DRIVE_MULTIPART_THRESHOLD = int(os.getenv("EBRAINS_DRIVE_MULTIPART_THRESHOLD", 1024 * 1024 * 1024))
+"""Upper threshold for uploading large blob of file (default: 1G) Over which, multipart upload will be used..
+
+n.b. there is an undocumented upper hard threshold for single upload of 5G"""

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1,14 +1,19 @@
+import json
+from contextlib import nullcontext
 import pytest
 from unittest.mock import patch, mock_open
 from unittest.mock import MagicMock
 from ebrains_drive.bucket import Bucket
-from ebrains_drive.exceptions import ClientHttpError, Unauthorized
-from io import StringIO, IOBase
+from ebrains_drive.exceptions import ClientHttpError, Unauthorized, InvalidParameter, UpstreamAPIException
+from io import StringIO, BytesIO, IOBase
 from itertools import product
 from tempfile import mkstemp
 import os
 
+# sentinel to make intent explicit and remove typo possibilities
 TMP_PATH_SYMBOL = object()
+STR_PATH_SYMBOL = object()
+FILE_LIKE_SYMBOL = object()
 
 class MockClient:
     def get(self, *args, **kwargs):
@@ -123,3 +128,200 @@ def test_upload(filelike, kwargs, upload_fixture):
     else:
         raise RuntimeError(f" should be either str or IOBase")
     mocked_request.assert_called_with("PUT", "http://foo-bar.co/", data=data, **kwargs)
+
+
+# Patch to 64 bytes so tests don't need large files on disk.
+SMALL_CHUNK_SIZE = 64
+
+
+def _make_bucket():
+    client = MockClient()
+    return Bucket.from_json(client, bucket_json)
+
+
+# --- _get_filesize ---
+
+@pytest.mark.parametrize("make_input,expected_size,check_seek", [
+    pytest.param(STR_PATH_SYMBOL, 11, False, id="str-path"),
+    pytest.param(FILE_LIKE_SYMBOL, 42, True, id="file-like"),
+])
+def test_get_filesize(tmp_path, make_input, expected_size, check_seek):
+    bucket = _make_bucket()
+    if make_input is STR_PATH_SYMBOL:
+        p = tmp_path / "sample.bin"
+        p.write_bytes(b"hello world")
+        input_ = str(p)
+    else:
+        input_ = BytesIO(b"x" * 42)
+        input_.seek(5)  # advance pointer to confirm it gets reset
+    assert bucket._get_filesize(input_) == expected_size
+    if check_seek:
+        assert input_.tell() == 0  # pointer restored to start
+
+
+# --- _can_multipart_upload ---
+
+def _write(path, data):
+    path.write_bytes(data)
+    return path
+
+@pytest.mark.parametrize("make_input,expected_size,raises", [
+    (lambda tmp_path: str(_write(tmp_path / "big.bin", b"0" * (SMALL_CHUNK_SIZE + 1))), SMALL_CHUNK_SIZE + 1, False),
+    (lambda tmp_path: str(_write(tmp_path / "small.bin", b"tiny")),                     None,                 True),
+    (lambda tmp_path: str(_write(tmp_path / "exact.bin", b"0" * SMALL_CHUNK_SIZE)),     None,                 True),
+    (lambda tmp_path: BytesIO(b"0" * (SMALL_CHUNK_SIZE + 10)),                          SMALL_CHUNK_SIZE + 10, False),
+])
+@patch("ebrains_drive.bucket.EBRAINS_DRIVE_MULTIPART_CHUNK_SIZE", SMALL_CHUNK_SIZE)
+def test_can_multipart_upload(tmp_path, make_input, expected_size, raises):
+    src = make_input(tmp_path)
+    bucket = _make_bucket()
+    if raises:
+        with pytest.raises(InvalidParameter):
+            bucket._can_multipart_upload(src)
+    else:
+        assert bucket._can_multipart_upload(src) == expected_size
+
+
+# --- upload falls back to multipart_upload ---
+
+SMALL_THRESHOLD = 128
+
+
+@pytest.mark.parametrize("file_size,expect_multipart", [
+    pytest.param(SMALL_THRESHOLD + 1, True,  id="exceeds-threshold"),
+    pytest.param(SMALL_THRESHOLD,     False, id="at-threshold"),
+])
+@patch("ebrains_drive.bucket.EBRAINS_DRIVE_MULTIPART_THRESHOLD", SMALL_THRESHOLD)
+def test_upload_multipart_threshold(tmp_path, file_size, expect_multipart):
+    f = tmp_path / "file.bin"
+    f.write_bytes(b"x" * file_size)
+
+    mock_client = MockClient()
+    mock_client.put = MagicMock(return_value=MockHttpResp({"url": "http://example.com/upload"}))
+    bucket = Bucket.from_json(mock_client, bucket_json)
+
+    with patch.object(bucket, "multipart_upload") as mock_multipart:
+        with patch("requests.request", return_value=MockHttpResp({})):
+            bucket.upload(str(f), "dest/file.bin", extra="kwarg")
+        if expect_multipart:
+            mock_multipart.assert_called_once_with(str(f), "dest/file.bin", extra="kwarg")
+        else:
+            mock_multipart.assert_not_called()
+
+
+# --- multipart_upload ---
+
+MULTIPART_CHUNK_SIZE = 64
+
+
+def _make_multipart_bucket():
+    client = MockClient()
+    client.put = MagicMock()
+    return Bucket.from_json(client, bucket_json), client
+
+
+class MockPresignedResp:
+    """Simulates a presigned-URL PUT response with an ETag header."""
+
+    def __init__(self, etag="abc123"):
+        self.headers = {"etag": f'"{etag}"'}
+
+    def raise_for_status(self):
+        pass
+
+
+@pytest.mark.parametrize("use_file_path,data,expected_part_count", [
+    (True,  b"A" * (MULTIPART_CHUNK_SIZE * 2 + 10), 3),
+    (False, b"B" * (MULTIPART_CHUNK_SIZE + 5),       2),
+])
+@patch("ebrains_drive.bucket.EBRAINS_DRIVE_MULTIPART_CHUNK_SIZE", MULTIPART_CHUNK_SIZE)
+def test_multipart_upload_fresh(tmp_path, use_file_path, data, expected_part_count):
+    """Full fresh upload from a file path or BytesIO: obtains uploadId, uploads parts, completes."""
+    presigned_url = "http://presigned.example.com/part"
+
+    if use_file_path:
+        f = tmp_path / "big.bin"
+        f.write_bytes(data)
+        source = str(f)
+        dest = "dest/big.bin"
+    else:
+        source = BytesIO(data)
+        dest = "dest/stream.bin"
+
+    bucket, client = _make_multipart_bucket()
+    client.put.side_effect = (
+        [MockHttpResp({"uploadId": "uid-fresh"})]
+        + [MockHttpResp({"url": presigned_url})] * expected_part_count
+        + [MockHttpResp({})]
+    )
+
+    with patch("requests.Session") as MockSession:
+        sess = MockSession.return_value
+        sess.put.return_value = MockPresignedResp("etag-x")
+        bucket.multipart_upload(source, dest)
+
+    assert sess.put.call_count == expected_part_count
+    if use_file_path:
+        assert not os.path.exists(source + ".multipart_manifest.json")
+
+
+@patch("ebrains_drive.bucket.EBRAINS_DRIVE_MULTIPART_CHUNK_SIZE", MULTIPART_CHUNK_SIZE)
+def test_multipart_upload_resumes_from_manifest(tmp_path):
+    """If a manifest exists, upload resumes from next_offset without re-uploading completed parts."""
+    chunk = MULTIPART_CHUNK_SIZE
+    data = b"C" * (chunk * 3)
+    f = tmp_path / "resume.bin"
+    f.write_bytes(data)
+
+    upload_id = "uid-resume"
+    existing_etags = {"1": "etag-part1"}
+    manifest = {
+        "upload_id": upload_id,
+        "etag_maps": existing_etags,
+        "next_offset": chunk,  # first chunk already uploaded
+    }
+    manifest_path = str(f) + ".multipart_manifest.json"
+    with open(manifest_path, "w") as mf:
+        json.dump(manifest, mf)
+
+    bucket, client = _make_multipart_bucket()
+    presigned_url = "http://presigned.example.com/part"
+
+    client.put.side_effect = [
+        MockHttpResp({"url": presigned_url}),   # part 2
+        MockHttpResp({"url": presigned_url}),   # part 3
+        MockHttpResp({}),                        # complete
+    ]
+
+    with patch("requests.Session") as MockSession:
+        sess = MockSession.return_value
+        sess.put.return_value = MockPresignedResp("etag-resumed")
+        bucket.multipart_upload(str(f), "dest/resume.bin")
+
+    # Only 2 parts uploaded (part 1 was already done)
+    assert sess.put.call_count == 2
+    # Manifest cleaned up after success
+    assert not os.path.exists(manifest_path)
+
+
+@pytest.mark.parametrize("put_side_effect,use_session", [
+    (MockHttpResp({}), False),                                              # no uploadId
+    ([MockHttpResp({"uploadId": "uid-nourl"}), MockHttpResp({})], True),   # no presigned URL
+])
+@patch("ebrains_drive.bucket.EBRAINS_DRIVE_MULTIPART_CHUNK_SIZE", MULTIPART_CHUNK_SIZE)
+def test_multipart_upload_raises_on_missing_server_field(tmp_path, put_side_effect, use_session):
+    """UpstreamAPIException raised when the server omits uploadId or a presigned URL."""
+    data = b"D" * (MULTIPART_CHUNK_SIZE + 1)
+    f = tmp_path / "bad.bin"
+    f.write_bytes(data)
+
+    bucket, client = _make_multipart_bucket()
+    if isinstance(put_side_effect, list):
+        client.put.side_effect = put_side_effect
+    else:
+        client.put.return_value = put_side_effect
+
+    ctx = patch("requests.Session") if use_session else nullcontext()
+    with ctx:
+        with pytest.raises(UpstreamAPIException):
+            bucket.multipart_upload(str(f), "dest/bad.bin")

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -5,7 +5,10 @@ from ebrains_drive.bucket import Bucket
 from ebrains_drive.exceptions import ClientHttpError, Unauthorized
 from io import StringIO, IOBase
 from itertools import product
+from tempfile import mkstemp
+import os
 
+TMP_PATH_SYMBOL = object()
 
 class MockClient:
     def get(self, *args, **kwargs):
@@ -13,14 +16,6 @@ class MockClient:
 
     def put(self, *args, **kwargs):
         raise NotImplementedError
-
-
-@pytest.fixture
-def mock_client():
-    client = MockClient()
-    client.get = MagicMock()
-    client.put = MagicMock()
-    return client
 
 
 class MockHttpResp:
@@ -86,36 +81,44 @@ def test_ls_when_repeats():
 
 
 @pytest.fixture
-def mocked_request():
-    try:
-        with patch("requests.request") as patched_obj:
-            yield patched_obj
-    finally:
-        ...
+def upload_fixture():
 
+    mock_client = MockClient()
+    mock_client.get = MagicMock()
+    mock_client.put = MagicMock()
 
-@pytest.fixture
-def mock_open_fixture():
-    try:
-        with patch("builtins.open", new_callable=mock_open, read_data="foo-bar") as patched_obj:
-            patched_obj.return_value.seek.return_value = 7
-            yield patched_obj
-    finally:
-        ...
-
-
-@pytest.mark.parametrize("filelike,kwargs", product(["filelike", StringIO()], [{"foo": "bar"}, {}]))
-def test_upload(filelike, kwargs, mocked_request, mock_open_fixture, mock_client: MockClient):
-    bucket = Bucket.from_json(mock_client, bucket_json)
-    mocked_request.return_value = MockHttpResp({})
     mock_client.put.return_value = MockHttpResp({"url": "http://foo-bar.co/"})
+
+    bucket = Bucket.from_json(mock_client, bucket_json)
+    _, fname = mkstemp()
+
+    with open(fname, "w") as fp:
+        fp.write("foo-bar")
+
+    try:
+
+        with patch("requests.request") as mocked_request:
+            mocked_request.return_value = MockHttpResp({})
+            with patch("builtins.open", new_callable=mock_open) as patched_open:
+                yield patched_open, mocked_request, bucket, fname
+    finally:
+        os.unlink(fname)
+
+
+@pytest.mark.parametrize("filelike,kwargs", product([TMP_PATH_SYMBOL, StringIO()], [{"foo": "bar"}, {}]))
+def test_upload(filelike, kwargs, upload_fixture):
+
+    patched_open, mocked_request, bucket, tmp_filename = upload_fixture
+
+    if filelike == TMP_PATH_SYMBOL:
+        filelike = tmp_filename
 
     bucket.upload(filelike, "filename", **kwargs)
     if isinstance(filelike, str):
-        mock_open_fixture.assert_called()
-        data = mock_open_fixture.return_value
+        patched_open.assert_called()
+        data = patched_open.return_value
     elif isinstance(filelike, IOBase):
-        mock_open_fixture.assert_not_called()
+        patched_open.assert_not_called()
         data = filelike
     else:
         raise RuntimeError(f" should be either str or IOBase")

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -98,6 +98,7 @@ def mocked_request():
 def mock_open_fixture():
     try:
         with patch("builtins.open", new_callable=mock_open, read_data="foo-bar") as patched_obj:
+            patched_obj.return_value.seek.return_value = 7
             yield patched_obj
     finally:
         ...


### PR DESCRIPTION
Up until this point, artefact upload >5G will fail due to undocumented gateway settings. Additionally, uploading large artefacts run into the risk of interruption. 

This PR adds multipart upload. upload will automatically default to multipart upload if the size > 1GB. 